### PR TITLE
[schema-registry] update PDB to make it available on k8s 1.25

### DIFF
--- a/charts/cp-schema-registry/templates/pdb.yaml
+++ b/charts/cp-schema-registry/templates/pdb.yaml
@@ -1,5 +1,5 @@
 {{- if .Values.podDisruptionBudget }}
-apiVersion: policy/v1beta1
+apiVersion: policy/v1
 kind: PodDisruptionBudget
 metadata:
   name: {{ .Release.Name }}


### PR DESCRIPTION
## What changes were proposed in this pull request?

`policy/v1beta1` is deprecated since k8s 1.21, let's update it to make it available in 1.25 where it is removed.

