### PR TITLE
[schema-registry] Remove deprecated UseCGroupMemoryLimitForHeap which has been replaced and on by default

### DIFF
--- a/charts/cp-schema-registry/CHANGELOG.md
+++ b/charts/cp-schema-registry/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## cp-schema-registry-v7.3.1-bbc-5
+* Remove deprecated `UseCGroupMemoryLimitForHeap` which has been replaced by `UseContainerSupport` and is on by default
+
 ## cp-schema-registry-v7.3.1-bbc-4
 * use bbc-registry image for kafka-prometheus-jmx-exporter
 

--- a/charts/cp-schema-registry/templates/deployment.yaml
+++ b/charts/cp-schema-registry/templates/deployment.yaml
@@ -52,7 +52,6 @@ spec:
           command:
           - java
           - -XX:+UnlockExperimentalVMOptions
-          - -XX:+UseCGroupMemoryLimitForHeap
           - -XX:MaxRAMFraction=1
           - -XshowSettings:vm
           - -jar


### PR DESCRIPTION


## What changes were proposed in this pull request?

(Please fill in changes proposed in this fix)

## How was this patch tested?

(Please explain how this patch was tested. E.g. helm upgrade on minikube, helm install on gke)
