### PR TITLE
Use (GKE) compute-class + boyscout cleanings

### DIFF
--- a/charts/cp-schema-registry/CHANGELOG.md
+++ b/charts/cp-schema-registry/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## cp-schema-registry-v7.3.1-bbc-6
+* Use (GKE) compute-class
+  BREAKING-CHANGE: we're replacing the `tolerations`+`nodeSelector` values by a single `scheduling.nodepool` (enum)
+* Better default values
+
 ## cp-schema-registry-v7.3.1-bbc-5
 * Remove deprecated `UseCGroupMemoryLimitForHeap` which has been replaced by `UseContainerSupport` and is on by default
 

--- a/charts/cp-schema-registry/templates/_helpers.tpl
+++ b/charts/cp-schema-registry/templates/_helpers.tpl
@@ -107,6 +107,6 @@ nodeSelector:
 {{- else if eq .nodepool "common" }}
 # No tolerations/nodeSelector for common nodepool
 {{- else }}
-{{- fail "Invalid value nodepool" }}
+{{- fail (printf "Invalid value for nodepool: '%s', expecting 'bursty', 'common' or 'datastores'." .nodepool) }}
 {{- end }}
 {{- end }}

--- a/charts/cp-schema-registry/templates/_helpers.tpl
+++ b/charts/cp-schema-registry/templates/_helpers.tpl
@@ -87,3 +87,26 @@ tags.datadoghq.com/version: {{ .Values.imageTag | quote }}
 {{- end }}
 {{- end }}
 {{- end }}
+
+{{/*
+Scheduling options for pods: input param should be the usual "scheduling" struct
+*/}}
+{{- define "scheduling-options" }}
+{{- if eq .nodepool "datastores" }}
+# NB: no tolerations here, the compute-class handles it for us
+nodeSelector:
+  cloud.google.com/compute-class: "datastores"
+{{- else if eq .nodepool "bursty" }}
+tolerations:
+- key: dedicated
+  operator: Equal
+  value: "bursty"
+  effect: NoSchedule
+nodeSelector:
+  dedicated: "bursty"
+{{- else if eq .nodepool "common" }}
+# No tolerations/nodeSelector for common nodepool
+{{- else }}
+{{- fail "Invalid value nodepool" }}
+{{- end }}
+{{- end }}

--- a/charts/cp-schema-registry/templates/deployment.yaml
+++ b/charts/cp-schema-registry/templates/deployment.yaml
@@ -150,13 +150,9 @@ spec:
         configMap:
           name: {{ template "cp-schema-registry.fullname" . }}-jmx-configmap
       {{- end }}
-      {{- if .Values.nodeSelector }}
-      nodeSelector:
-{{ toYaml .Values.nodeSelector | indent 8 }}
-      {{- end }}
-      {{- if .Values.tolerations }}
-      tolerations:
-{{ toYaml .Values.tolerations | indent 8 }}
+      # Tolerations/nodeSelector:
+      {{- with $.Values.scheduling }}
+      {{- include "scheduling-options" . | indent 6 }}
       {{- end }}
       affinity:
         podAntiAffinity:

--- a/charts/cp-schema-registry/values.yaml
+++ b/charts/cp-schema-registry/values.yaml
@@ -7,7 +7,7 @@
 ## ------------------------------------------------------
 
 ## Number of Scheme Registry Pod
-replicaCount: 1
+replicaCount: 2
 
 ## Image Info
 ## ref: https://hub.docker.com/r/confluentinc/cp-schema-registry/
@@ -107,7 +107,7 @@ datadog:
       }
       }]
   labels:
-    team: "team_dbre"
+    team: "dbre"
 
 ## Custom pod annotations
 podAnnotations:
@@ -143,12 +143,13 @@ prometheus:
     port: 5556
     resources: {}
   serviceMonitor: # defines monitoring for a service when using prometheus operator
-    enabled: true
+    enabled: false
     jobLabel: app
 
 ui:
   annotations: {}
-  labels: {}
+  labels:
+    team: dbre
   replicaCount: 1
   resources:
     requests:

--- a/charts/cp-schema-registry/values.yaml
+++ b/charts/cp-schema-registry/values.yaml
@@ -113,19 +113,6 @@ datadog:
 podAnnotations:
   cluster-autoscaler.kubernetes.io/safe-to-evict: "true"  # Allow the autoscaler to downscale the cluster.
 
-## Node labels for pod assignment
-## Ref: https://kubernetes.io/docs/concepts/configuration/assign-pod-node/
-nodeSelector:
-  dedicated: "datastores"
-
-## Taints to tolerate on node assignment:
-## Ref: https://kubernetes.io/docs/concepts/configuration/taint-and-toleration/
-tolerations:
-  - key: dedicated
-    operator: Equal
-    value: "datastores"
-    effect: NoSchedule
-
 podDisruptionBudget:
   maxUnavailable: 1
 
@@ -169,3 +156,6 @@ ui:
       memory: 30Mi
     limits:
       memory: 100Mi
+
+scheduling:
+  nodepool: datastores   # enum: datastores, common, bursty


### PR DESCRIPTION
## What changes were proposed in this pull request?

Mainly the configuration of compute-class ([DBRE-4853](https://blablacar.atlassian.net/browse/DBRE-4853))
And (boyscout, cf 2nd commit): a few cleanings of values

## How was this patch tested?
```
git sw master
helm template schemreg . > old.yaml

git sw compute-class
vim -d  old.yaml  <(helm template schemreg .)
```


[DBRE-4853]: https://blablacar.atlassian.net/browse/DBRE-4853?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ